### PR TITLE
feat: add CRUD API datasheet y datasheetCollection

### DIFF
--- a/api/src/config/container.ts
+++ b/api/src/config/container.ts
@@ -6,10 +6,14 @@ import process from "node:process";
 import MongooseUserRepository from "../repositories/mongoose/UserRepository";
 import MongoosePricingRepository from "../repositories/mongoose/PricingRepository";
 import MongoosePricingCollectionRepository from "../repositories/mongoose/PricingCollectionRepository";
+import MongooseDatasheetRepository from "../repositories/mongoose/DatasheetRepository";
+import MongooseDatasheetCollectionRepository from "../repositories/mongoose/DatasheetCollectionRepository";
 
 import UserService from "../services/UserService";
 import PricingService from "../services/PricingService";
 import PricingCollectionService from "../services/PricingCollectionService";
+import DatasheetService from "../services/DatasheetService";
+import DatasheetCollectionService from "../services/DatasheetCollectionService";
 import CacheService from "../services/CacheService";
 
 dotenv.config();
@@ -17,11 +21,14 @@ dotenv.config();
 function initContainer(databaseType: string): AwilixContainer {
   const container: AwilixContainer = createContainer();
   let userRepository, pricingRepository, pricingCollectionRepository;
+  let datasheetRepository, datasheetCollectionRepository;
   switch (databaseType) {
     case "mongoDB":
       userRepository = new MongooseUserRepository();
       pricingRepository = new MongoosePricingRepository();
       pricingCollectionRepository = new MongoosePricingCollectionRepository();
+      datasheetRepository = new MongooseDatasheetRepository();
+      datasheetCollectionRepository = new MongooseDatasheetCollectionRepository();
       break;
     default:
       throw new Error(`Unsupported database type: ${databaseType}`);
@@ -30,9 +37,13 @@ function initContainer(databaseType: string): AwilixContainer {
     userRepository: asValue(userRepository),
     pricingRepository: asValue(pricingRepository),
     pricingCollectionRepository: asValue(pricingCollectionRepository),
+    datasheetRepository: asValue(datasheetRepository),
+    datasheetCollectionRepository: asValue(datasheetCollectionRepository),
     userService: asClass(UserService).singleton(),
     pricingService: asClass(PricingService).singleton(),
     pricingCollectionService: asClass(PricingCollectionService).singleton(),
+    datasheetService: asClass(DatasheetService).singleton(),
+    datasheetCollectionService: asClass(DatasheetCollectionService).singleton(),
     cacheService: asClass(CacheService).singleton(),
   });
   return container;

--- a/api/src/controllers/DatasheetCollectionController.ts
+++ b/api/src/controllers/DatasheetCollectionController.ts
@@ -1,0 +1,142 @@
+import container from '../config/container';
+import DatasheetCollectionService from '../services/DatasheetCollectionService';
+import { DatasheetCollectionIndexQueryParams } from '../types/services/DatasheetCollection';
+
+class DatasheetCollectionController {
+  private datasheetCollectionService: DatasheetCollectionService;
+
+  constructor() {
+    this.datasheetCollectionService = container.resolve('datasheetCollectionService');
+    this.index = this.index.bind(this);
+    this.showByNameAndUserId = this.showByNameAndUserId.bind(this);
+    this.show = this.show.bind(this);
+    this.showByUserId = this.showByUserId.bind(this);
+    this.create = this.create.bind(this);
+    this.bulkCreate = this.bulkCreate.bind(this);
+    this.update = this.update.bind(this);
+    this.destroy = this.destroy.bind(this);
+  }
+
+  async index(req: any, res: any) {
+    try {
+      const queryParams: DatasheetCollectionIndexQueryParams = {
+        name: req.query.name as string,
+        sortBy: req.query.sortBy as string,
+        sort: req.query.sort as "asc" | "desc" | undefined,
+        selectedOwners: req.query.selectedOwners ? (req.query.selectedOwners as string).split(',') : undefined,
+      };
+
+      const pagination = {
+        limit: req.query.limit,
+        offset: req.query.offset,
+      };
+
+      const collections = await this.datasheetCollectionService.index(Object.assign({}, queryParams, pagination));
+      res.json(collections);
+    } catch (err: any) {
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async showByNameAndUserId(req: any, res: any) {
+    try {
+      const collection = await this.datasheetCollectionService.showByNameAndUserId(
+        req.params.collectionName,
+        req.params.userId
+      );
+      res.json(collection);
+    } catch (err: any) {
+      if (err.message.toLowerCase().includes('not found')) {
+        res.status(404).send({ error: err.message });
+      } else {
+        res.status(500).send({ error: err.message });
+      }
+    }
+  }
+
+  async show(req: any, res: any) {
+    try {
+      const { ownerId } = req.params;
+      const collection = await this.datasheetCollectionService.show(ownerId);
+      res.json(collection);
+    } catch (err: any) {
+      if (err.message.toLowerCase().includes('not found')) {
+        res.status(404).send({ error: err.message });
+      } else {
+        res.status(500).send({ error: err.message });
+      }
+    }
+  }
+
+  async showByUserId(req: any, res: any) {
+    try {
+      const collections = await this.datasheetCollectionService.showByUserId(req.user.id);
+      res.json({ collections: collections });
+    } catch (err: any) {
+      if (err.message.toLowerCase().includes('not found')) {
+        res.status(404).send({ error: err.message });
+      } else {
+        res.status(500).send({ error: err.message });
+      }
+    }
+  }
+
+  async create(req: any, res: any) {
+    try {
+      const collection = await this.datasheetCollectionService.create(req.body, req.user.id, req.user.username);
+      res.json(collection);
+    } catch (err: any) {
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async bulkCreate(req: any, res: any) {
+    try {
+      const [collection, datasheetsWithErrors] = await this.datasheetCollectionService.bulkCreate(
+        req.file,
+        JSON.parse(req.body.collectionData),
+        req.user.id,
+        req.user.username
+      );
+      res.json({ collection, datasheetsWithErrors });
+    } catch (err: any) {
+      if (err.message.includes('A collection with this name already exists')) {
+        res.status(409).send({ error: err.message });
+        return;
+      }
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async update(req: any, res: any) {
+    try {
+      const collection = await this.datasheetCollectionService.update(
+        req.params.collectionName,
+        req.user.id,
+        req.body
+      );
+      res.json(collection);
+    } catch (err: any) {
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async destroy(req: any, res: any) {
+    try {
+      await this.datasheetCollectionService.destroy(
+        req.params.collectionName,
+        req.user.id,
+        Boolean(req.query.deleteCascade)
+      );
+      res.status(200).send({ message: 'Collection deleted successfully' });
+    } catch (err: any) {
+      if (err.message.toLowerCase().includes('not exist')) {
+        res.status(404).send({ error: err.message });
+      } else {
+        res.status(500).send({ error: err.message });
+      }
+    }
+  }
+}
+
+export default DatasheetCollectionController;

--- a/api/src/controllers/DatasheetController.ts
+++ b/api/src/controllers/DatasheetController.ts
@@ -1,0 +1,167 @@
+import fs from 'fs';
+import container from '../config/container.js';
+import DatasheetService from '../services/DatasheetService';
+import path from 'path';
+import { DatasheetIndexQueryParams } from '../types/services/DatasheetService.js';
+
+class DatasheetController {
+  private datasheetService: DatasheetService;
+
+  constructor() {
+    this.datasheetService = container.resolve('datasheetService');
+    this.index = this.index.bind(this);
+    this.indexByUserWithoutCollection = this.indexByUserWithoutCollection.bind(this);
+    this.show = this.show.bind(this);
+    this.create = this.create.bind(this);
+    this.addDatasheetToCollection = this.addDatasheetToCollection.bind(this);
+    this.update = this.update.bind(this);
+    this.removeDatasheetFromCollection = this.removeDatasheetFromCollection.bind(this);
+    this.destroyByNameAndOwner = this.destroyByNameAndOwner.bind(this);
+    this.destroyVersionByNameAndOwner = this.destroyVersionByNameAndOwner.bind(this);
+  }
+
+  async index(req: any, res: any) {
+    try {
+      const queryParams: DatasheetIndexQueryParams = {
+        name: req.query.name as string,
+        sortBy: req.query.sortBy as string,
+        sort: req.query.sort as "asc" | "desc" | undefined,
+        selectedOwners: req.query.selectedOwners ? (req.query.selectedOwners as string).split(',') : undefined,
+      };
+
+      const pagination = {
+        limit: req.query.limit,
+        offset: req.query.offset,
+      };
+
+      const datasheets = await this.datasheetService.index(Object.assign({}, queryParams, pagination));
+      res.json(datasheets);
+    } catch (err: any) {
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async indexByUserWithoutCollection(req: any, res: any) {
+    try {
+      const datasheets = await this.datasheetService.indexByUserWithoutCollection(req.user.username);
+      res.json({ datasheets });
+    } catch (err: any) {
+      res.status(500).send(err.message);
+    }
+  }
+
+  async show(req: any, res: any) {
+    try {
+      const queryParams = req.query;
+      const datasheet = await this.datasheetService.show(
+        req.params.datasheetName,
+        req.params.owner,
+        queryParams
+      );
+      res.json(datasheet);
+    } catch (err: any) {
+      if (err.message.toLowerCase().includes('not found')) {
+        res.status(404).send({ error: err.message });
+      } else {
+        res.status(500).send({ error: err.message });
+      }
+    }
+  }
+
+  async create(req: any, res: any) {
+    try {
+      const datasheet = await this.datasheetService.create(req.file, req.user.username);
+      res.json(datasheet);
+    } catch (err: any) {
+      try {
+        const file = req.file;
+        // Only removing file on error for Datasheets, we simplify the cleanup
+        if (file?.path && fs.existsSync(file.path)) {
+            fs.rmSync(file.path);
+        }
+        res.status(500).send({ error: err.message });
+      } catch (err) {
+        res.status(500).send({ error: (err as Error).message });
+      }
+    }
+  }
+
+  async addDatasheetToCollection(req: any, res: any) {
+    try {
+      const result = await this.datasheetService.addDatasheetToCollection(
+        req.body.datasheetName,
+        req.user.username,
+        req.body.collectionId
+      );
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async update(req: any, res: any) {
+    try {
+      const datasheet = await this.datasheetService.update(
+        req.params.datasheetName,
+        req.user.username,
+        req.body
+      );
+      res.json(datasheet);
+    } catch (err: any) {
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async removeDatasheetFromCollection(req: any, res: any) {
+    try {
+      const result = await this.datasheetService.removeDatasheetFromCollection(
+        req.params.datasheetName,
+        req.user.username
+      );
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async destroyByNameAndOwner(req: any, res: any) {
+    try {
+      const queryParams = req.query;
+      const result = await this.datasheetService.destroy(
+        req.params.datasheetName,
+        req.user.username,
+        queryParams
+      );
+      if (!result) {
+        res.status(404).send({ error: 'Datasheet not found' });
+      } else {
+        res.status(200).send({ message: 'Datasheet deleted successfully' });
+      }
+    } catch (err: any) {
+      res.status(500).send({ error: err.message });
+    }
+  }
+
+  async destroyVersionByNameAndOwner(req: any, res: any) {
+    try {
+      const result = await this.datasheetService.destroyVersion(
+        req.params.datasheetName,
+        req.params.datasheetVersion,
+        req.user.username
+      );
+      if (!result) {
+        res.status(404).send({ error: 'Datasheet version not found' });
+      } else {
+        res.status(200).send({ message: 'Datasheet version deleted successfully' });
+      }
+    } catch (err: any) {
+      if (err.message.toLowerCase().includes('not exist')) {
+        res.status(404).send({ error: err.message });
+      } else {
+        res.status(500).send({ error: err.message });
+      }
+    }
+  }
+}
+
+export default DatasheetController;

--- a/api/src/repositories/mongoose/DatasheetCollectionRepository.ts
+++ b/api/src/repositories/mongoose/DatasheetCollectionRepository.ts
@@ -1,0 +1,328 @@
+import mongoose from 'mongoose';
+import RepositoryBase from '../RepositoryBase';
+import DatasheetCollectionMongoose from './models/DatasheetCollectionMongoose';
+import DatasheetMongoose from './models/DatasheetMongoose';
+import { processFileUris } from '../../services/FileService';
+import { getAllDatasheetsFromCollection } from './aggregators/get-datasheets-from-collection';
+import { addNumberOfDatasheetsAggregator } from './aggregators/datasheetCollections/add-number-of-datasheets';
+import { addOwnerToCollectionAggregator } from './aggregators/datasheetCollections/add-owner-to-collection';
+import { addLastDatasheetUpdateAggregator } from './aggregators/datasheetCollections/add-last-datasheet-update';
+import { DatasheetCollectionIndexQueryParams } from '../../types/services/DatasheetCollection';
+
+class DatasheetCollectionRepository extends RepositoryBase {
+  async findAll(queryParams: DatasheetCollectionIndexQueryParams, ...args: any) {
+    
+    let filteringAggregators = [];
+    let sortAggregator = [];
+
+    if (Object.keys(queryParams).length > 0){
+      const { name, selectedOwners, sortBy, sort } = queryParams;
+
+      if (name){
+        filteringAggregators.push({
+          $match: {
+            name: {
+              $regex: name,
+              $options: 'i', // case-insensitive
+            },
+          },
+        });
+      }
+
+      if (selectedOwners) {
+        const selectedOwnersFilter = selectedOwners as string[];
+
+        filteringAggregators.push({
+          $match: {
+            "owner.username": {
+              $in: selectedOwnersFilter,
+            },
+          },
+        });
+      }
+      if (sortBy && sort){
+
+        let sortParameter = "";
+        let sortOrder: 1 | -1 = sort === "asc" ? 1 : -1;
+
+        switch (sortBy) {
+          case 'numberOfDatasheets':
+            sortParameter = "numberOfDatasheets";
+            break;
+        };
+        sortAggregator.push({
+          $sort: {
+            [sortParameter]: sortOrder,
+          },
+        });
+      }
+    }
+    
+    
+    try {
+      // parse pagination params
+      const limitRaw = queryParams?.limit;
+      const offsetRaw = queryParams?.offset;
+
+      let limit: number | undefined;
+      let offset: number | undefined;
+
+      if (limitRaw !== undefined) {
+        limit = typeof limitRaw === 'string' ? parseInt(limitRaw, 10) : Number(limitRaw);
+        if (Number.isNaN(limit) || limit! < 0) limit = undefined;
+      }
+
+      if (offsetRaw !== undefined) {
+        offset = typeof offsetRaw === 'string' ? parseInt(offsetRaw, 10) : Number(offsetRaw);
+        if (Number.isNaN(offset) || offset! < 0) offset = undefined;
+      }
+
+      const basePipeline: any[] = [
+        {
+          $match: {
+            private: false,
+          },
+        },
+        ...addNumberOfDatasheetsAggregator(),
+        ...addOwnerToCollectionAggregator(),
+        ...filteringAggregators,
+        { $sort: { name: 1 } },
+        ...sortAggregator,
+        {
+          $project: {
+            owner: {
+              username: 1,
+              avatar: 1,
+              id: { $toString: '$owner._id' },
+            },
+            name: 1,
+            numberOfDatasheets: 1,
+          },
+        },
+      ];
+
+      if (typeof offset !== 'undefined' || typeof limit !== 'undefined') {
+        const start = offset || 0;
+        const take = typeof limit !== 'undefined' ? limit : Number.MAX_SAFE_INTEGER;
+
+        const facetPipeline = [
+          {
+            $facet: {
+              collections: [
+                { $skip: start },
+                { $limit: take },
+              ],
+              total: [
+                { $count: 'count' },
+              ],
+            },
+          },
+        ];
+
+        const aggResult = await DatasheetCollectionMongoose.aggregate([...basePipeline, ...facetPipeline]);
+        const first = aggResult[0] || { collections: [], total: [] };
+        const collections = first.collections || [];
+        const total = (first.total && first.total[0] && first.total[0].count) || 0;
+
+        collections.forEach((c: any) => processFileUris(c.owner, ['avatar']));
+        return { collections, total };
+      }
+
+      const collections = await DatasheetCollectionMongoose.aggregate(basePipeline);
+      collections.forEach((c: any) => processFileUris(c.owner, ['avatar']));
+      const total = collections.length;
+      return { collections, total };
+    } catch (err) {
+      return { collections: [], total: 0 };
+    }
+  }
+
+  async findById(id: string, ...args: any) {
+    try {
+      const collections = await DatasheetCollectionMongoose.aggregate([
+        {
+          $match: {
+            _id: new mongoose.Types.ObjectId(id),
+          },
+        },
+        ...getAllDatasheetsFromCollection(),
+        {
+          $project: {
+            name: 1,
+            description: 1,
+            analytics: 1,
+            datasheets: 1,
+          },
+        },
+      ]);
+
+      return collections[0];
+    } catch (err) {
+      return null;
+    }
+  }
+
+  async findByUserId(userId: string, ...args: any) {
+    try {
+      const collections = await DatasheetCollectionMongoose.aggregate([
+        {
+          $match: {
+            _ownerId: new mongoose.Types.ObjectId(userId),
+          },
+        },
+        ...addNumberOfDatasheetsAggregator(),
+        ...addOwnerToCollectionAggregator(),
+        {
+          $addFields: {
+            id: { $toString: '$_id' },
+          }
+        },
+        {
+          $project: {
+            id: 1,
+            _id: 0,
+            owner: {
+              username: 1,
+              avatar: 1,
+              id: { $toString: '$owner._id' },
+            },
+            name: 1,
+            numberOfDatasheets: 1,
+          },
+        },
+      ]);
+
+      return collections;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  async findByNameAndUserId(name: string, userId: string, ...args: any) {
+    try {
+      const collections = await DatasheetCollectionMongoose.aggregate([
+        {
+          $match: {
+            name: {
+              $regex: name,
+              $options: 'i',
+            },
+            _ownerId: new mongoose.Types.ObjectId(userId),
+          },
+        },
+        ...getAllDatasheetsFromCollection(),
+        ...addOwnerToCollectionAggregator(),
+        ...addLastDatasheetUpdateAggregator(),
+        {
+          $addFields: {
+            id: { $toString: '$_id' },
+          }
+        },
+        {
+          $project: {
+            id: 1,
+            owner: {
+              username: 1,
+              avatar: 1,
+              id: { $toString: '$owner._id' },
+            },
+            name: 1,
+            description: 1,
+            private: 1,
+            analytics: 1,
+            datasheets: 1,
+            lastUpdate: 1,
+          },
+        },
+      ]);
+
+      return collections[0];
+    } catch (err) {
+      console.log('[ERROR] An error occurred during the retrieval of the datasheet collection');
+      return null;
+    }
+  }
+
+  async findCollectionDatasheets(name: string, userId: string, ...args: any) {
+    try {
+      const collections = await DatasheetCollectionMongoose.aggregate([
+        {
+          $match: {
+            name: {
+              $regex: name,
+              $options: 'i',
+            },
+            _ownerId: new mongoose.Types.ObjectId(userId),
+          },
+        },
+        {
+          $lookup: {
+            from: 'datasheets',
+            localField: '_id',
+            foreignField: '_collectionId',
+            as: 'datasheets',
+          }
+        },
+        {
+          $project: {
+            datasheets: 1,
+          },
+        },
+      ]);
+
+      return collections[0];
+    } catch (err) {
+      return null;
+    }
+  }
+
+  async create(data: any, ...args: any) {
+    const collection = new DatasheetCollectionMongoose(data);
+    await collection.save();
+
+    return collection.populate('owner', {
+      username: 1,
+      avatar: 1,
+      id: 1,
+    });
+  }
+
+  async update(collectionId: string, data: any) {
+    const collection = await DatasheetCollectionMongoose.findById(collectionId);
+    
+    if (!collection) {
+      throw new Error('Collection not found in database');
+    }
+
+    collection.set(data);
+    await collection.save();
+
+    return collection.toJSON();
+  }
+
+  async setCollectionAnalytics(collectionId: string, analytics: any) {
+    const collection = await DatasheetCollectionMongoose.findById(collectionId);
+
+    if (!collection) {
+      throw new Error('Collection not found in database');
+    }
+
+    collection.set({ analytics });
+    await collection.save();
+
+    return collection.toJSON();
+  }
+
+  async destroy(id: string, ...args: any) {
+    const result = await DatasheetCollectionMongoose.deleteOne({ _id: id });
+    return result?.deletedCount === 1;
+  }
+
+  async destroyWithDatasheets(id: string, ...args: any) {
+    const resultDatasheets = await DatasheetMongoose.deleteMany({ _collectionId: new mongoose.Types.ObjectId(id) });
+    const resultCollections = await DatasheetCollectionMongoose.deleteOne({ _id: new mongoose.Types.ObjectId(id) });
+    return resultCollections?.deletedCount === 1 && resultDatasheets?.deletedCount > 0;
+  }
+}
+
+export default DatasheetCollectionRepository;

--- a/api/src/repositories/mongoose/DatasheetRepository.ts
+++ b/api/src/repositories/mongoose/DatasheetRepository.ts
@@ -1,0 +1,330 @@
+import RepositoryBase from '../RepositoryBase';
+import DatasheetMongoose from './models/DatasheetMongoose';
+import { getAllDatasheetsAggregator } from './aggregators/get-all-datasheets';
+import { DatasheetIndexQueryParams } from '../../types/services/DatasheetService';
+import mongoose from 'mongoose';
+import { getDatasheetByNameAndOwnerAggregator } from './aggregators/get-datasheet-by-name-and-owner';
+
+class DatasheetRepository extends RepositoryBase {
+  async findAll(...args: any) {
+    const queryParams: DatasheetIndexQueryParams = args[0];
+
+    let filteringAggregators = [];
+    let sortAggregator = [];
+
+    if (Object.keys(queryParams).length > 0) {
+      const { name, selectedOwners, sortBy, sort } = queryParams;
+
+      if (name) {
+        filteringAggregators.push({
+          $match: {
+            name: {
+              $regex: name,
+              $options: 'i', // case-insensitive
+            },
+          },
+        });
+      }
+
+      if (selectedOwners) {
+        const selectedOwnersFilter = selectedOwners as string[];
+
+        filteringAggregators.push({
+          $match: {
+            owner: {
+              $in: selectedOwnersFilter,
+            },
+          },
+        });
+      }
+      if (sortBy && sort) {
+        let sortParameter = '';
+        let sortOrder = sort === 'asc' ? 1 : -1;
+
+        switch (sortBy) {
+          case 'datasheetName':
+            sortParameter = 'name';
+            break;
+        }
+        sortAggregator.push({
+          $addFields: {
+            datasheets: {
+              $sortArray: {
+                input: '$datasheets',
+                sortBy: {
+                  [sortParameter]: sortOrder,
+                },
+              },
+            },
+          },
+        });
+      }
+    }
+
+    try {
+      const aggregator = getAllDatasheetsAggregator(filteringAggregators, sortAggregator);
+
+      // parse pagination params to integers
+      const limitRaw = queryParams?.limit;
+      const offsetRaw = queryParams?.offset;
+
+      let limit: number | undefined;
+      let offset: number | undefined;
+
+      if (limitRaw !== undefined) {
+        limit = typeof limitRaw === 'string' ? parseInt(limitRaw, 10) : Number(limitRaw);
+        if (Number.isNaN(limit) || limit! < 0) limit = undefined;
+      }
+
+      if (offsetRaw !== undefined) {
+        offset = typeof offsetRaw === 'string' ? parseInt(offsetRaw, 10) : Number(offsetRaw);
+        if (Number.isNaN(offset) || offset! < 0) offset = undefined;
+      }
+
+      const basePipeline: any[] = [
+        {
+          $match: {
+            private: false,
+          },
+        },
+        ...aggregator,
+      ];
+
+      if (typeof offset !== 'undefined' || typeof limit !== 'undefined') {
+        const start = offset || 0;
+        const take = typeof limit !== 'undefined' ? limit : Number.MAX_SAFE_INTEGER;
+
+        const paginationStages = [
+          {
+            $addFields: {
+              total: { $size: '$datasheets' },
+            },
+          },
+          {
+            $project: {
+              datasheets: {
+                $cond: [
+                  { $gt: [{ $size: '$datasheets' }, 0] },
+                  { $slice: ['$datasheets', start, take] },
+                  [],
+                ],
+              },
+              total: 1,
+            },
+          },
+        ];
+
+        const datasheets = await DatasheetMongoose.aggregate([...basePipeline, ...paginationStages]);
+        return datasheets[0] || { datasheets: [], total: 0 };
+      }
+
+      const datasheets = await DatasheetMongoose.aggregate(basePipeline);
+      const result = datasheets[0] || { datasheets: [], total: 0 };
+      if (typeof result.total === 'undefined') {
+        result.total = Array.isArray(result.datasheets) ? result.datasheets.length : 0;
+      }
+      return result;
+    } catch (err) {
+      return { datasheets: [] };
+    }
+  }
+
+  async findByOwnerWithoutCollection(owner: string, ...args: any) {
+    try {
+      const datasheets = await DatasheetMongoose.aggregate([
+        {
+          $match: {
+            owner: owner,
+            _collectionId: { $exists: false },
+          },
+        },
+        ...getAllDatasheetsAggregator([], []),
+      ]);
+
+      return datasheets[0];
+    } catch (err) {
+      return [];
+    }
+  }
+
+  async findByNameAndOwner(
+    name: string,
+    owner: string,
+    queryParams?: { collectionName?: string },
+    ...args: any
+  ) {
+    try {
+      let datasheet;
+      if (queryParams?.collectionName) {
+        datasheet = await DatasheetMongoose.aggregate([
+          ...getDatasheetByNameAndOwnerAggregator(name, owner),
+          {
+            $match: {
+              collectionName: queryParams.collectionName,
+            },
+          },
+        ]);
+      } else {
+        datasheet = await DatasheetMongoose.aggregate([
+          {
+            $match: {
+              _collectionId: { $exists: false },
+            },
+          },
+          ...getDatasheetByNameAndOwnerAggregator(name, owner),
+        ]);
+      }
+
+      if (!datasheet || datasheet.length === 0) {
+        return null;
+      }
+
+      return datasheet[0];
+    } catch (err) {
+      return null;
+    }
+  }
+
+  async findByCollection(collectionId: string, ...args: any) {
+    try {
+      const datasheets = await DatasheetMongoose.find({ _collectionId: collectionId });
+      return datasheets;
+    } catch (err) {
+      return [];
+    }
+  }
+
+  async findById(id: string, ...args: any[]): Promise<any> {
+    const datasheet = await DatasheetMongoose.findOne({ _id: new mongoose.Types.ObjectId(id) });
+    if (!datasheet) {
+      return null;
+    }
+    return datasheet.toJSON();
+  }
+
+  async create(data: any[], ...args: any) {
+    data.forEach(item => {
+      if (item._collectionId) {
+        item._collectionId = new mongoose.Types.ObjectId(item._collectionId);
+      }
+    });
+
+    return await DatasheetMongoose.insertMany(data);
+  }
+
+  async updateDatasheetsCollectionName(
+    datasheetsToUpdate: any,
+    ...args: any
+  ) {
+    const bulkOps = datasheetsToUpdate.map((datasheet: any) => ({
+      updateOne: {
+        filter: { _id: datasheet._id },
+        update: { $set: { yaml: datasheet.yaml } },
+      },
+    }));
+
+    const result = await DatasheetMongoose.bulkWrite(bulkOps);
+
+    return result.modifiedCount === datasheetsToUpdate.length;
+  }
+
+  async addDatasheetToCollection(datasheetName: string, owner: string, collectionId: string) {
+    return await DatasheetMongoose.updateMany(
+      {
+        name: datasheetName,
+        owner: owner,
+      },
+      {
+        $set: { _collectionId: new mongoose.Types.ObjectId(collectionId) },
+      }
+    );
+  }
+
+  async addDatasheetsToCollection(
+    collectionId: string,
+    owner: string,
+    datasheets: string[],
+    ...args: any
+  ) {
+    const result = await DatasheetMongoose.updateMany(
+      { name: { $in: datasheets }, owner: owner },
+      { $set: { _collectionId: new mongoose.Types.ObjectId(collectionId) } }
+    );
+
+    return result.modifiedCount === datasheets.length;
+  }
+
+  async update(id: string, data: any, ...args: any) {
+    const datasheet = await DatasheetMongoose.findOne({ _id: id });
+    if (!datasheet) {
+      return null;
+    }
+
+    datasheet.set(data);
+    await datasheet.save();
+
+    return datasheet.toJSON();
+  }
+
+  async removeDatasheetFromCollection(datasheetName: string, owner: string, ...args: any) {
+    return await DatasheetMongoose.updateMany(
+      {
+        name: datasheetName,
+        owner: owner,
+      },
+      {
+        $unset: { _collectionId: 1 },
+      }
+    );
+  }
+
+  async removeDatasheetsFromCollection(collectionId: string) {
+    return await DatasheetMongoose.updateMany(
+      {
+        _collectionId: new mongoose.Types.ObjectId(collectionId),
+      },
+      {
+        $unset: { _collectionId: 1 },
+      }
+    );
+  }
+
+  async destroyByNameOwnerAndCollectionId(name: string, owner: string, collectionId?: string) {
+    if (collectionId) {
+      const result = await DatasheetMongoose.deleteMany({
+        name: name,
+        owner: owner,
+        _collectionId: new mongoose.Types.ObjectId(collectionId),
+      });
+      return result.deletedCount >= 1;
+    } else {
+      const result = await DatasheetMongoose.deleteMany({
+        name: name,
+        owner: owner,
+        _collectionId: { $exists: false },
+      });
+      return result.deletedCount >= 1;
+    }
+  }
+
+  async destroyVersionByNameAndOwner(name: string, version: string, owner: string, ...args: any) {
+    const result = await DatasheetMongoose.deleteOne({
+      $expr: {
+        $and: [
+          { $eq: [{ $toLower: '$name' }, name.toLowerCase()] },
+          { $eq: ['$owner', owner] },
+          { $eq: ['$version', version] },
+        ],
+      },
+    });
+
+    return result.deletedCount === 1;
+  }
+
+  async destroy(id: string, ...args: any) {
+    const result = await DatasheetMongoose.deleteOne({ _id: id });
+    return result?.deletedCount === 1;
+  }
+}
+
+export default DatasheetRepository;

--- a/api/src/repositories/mongoose/aggregators/datasheetCollections/add-last-datasheet-update.ts
+++ b/api/src/repositories/mongoose/aggregators/datasheetCollections/add-last-datasheet-update.ts
@@ -1,0 +1,20 @@
+import { PipelineStage } from 'mongoose';
+
+export function addLastDatasheetUpdateAggregator(): PipelineStage[]{
+  return [
+    {
+      $set: {
+        lastUpdate: {
+          $max: "$datasheets.datasheets.extractionDate"
+        }
+      }
+    },
+    {
+      $set: {
+        lastUpdate: {
+          $max: "$lastUpdate"
+        }
+      }
+    }
+  ]
+}

--- a/api/src/repositories/mongoose/aggregators/datasheetCollections/add-number-of-datasheets.ts
+++ b/api/src/repositories/mongoose/aggregators/datasheetCollections/add-number-of-datasheets.ts
@@ -1,0 +1,25 @@
+import { getAllDatasheetsFromCollection } from '../get-datasheets-from-collection';
+
+export function addNumberOfDatasheetsAggregator() {
+  return [
+    ...getAllDatasheetsFromCollection(),
+    {
+      $addFields: {
+        datasheets: {
+          $arrayElemAt: ['$datasheets', 0],
+        },
+      },
+    },
+    {
+      $unwind: {
+        path: '$datasheets',
+        preserveNullAndEmptyArrays: true,
+      },
+    },
+    {
+      $addFields: {
+        numberOfDatasheets: { $size: { $ifNull: ['$datasheets.datasheets', []] } },
+      },
+    },
+  ];
+}

--- a/api/src/repositories/mongoose/aggregators/datasheetCollections/add-owner-to-collection.ts
+++ b/api/src/repositories/mongoose/aggregators/datasheetCollections/add-owner-to-collection.ts
@@ -1,0 +1,17 @@
+export function addOwnerToCollectionAggregator() {
+  return [
+    {
+      $lookup: {
+        from: 'users',
+        localField: '_ownerId',
+        foreignField: '_id',
+        as: 'owner',
+      },
+    },
+    {
+      $unwind: {
+        path: '$owner',
+      },
+    }
+  ]
+}

--- a/api/src/repositories/mongoose/aggregators/get-all-datasheets.ts
+++ b/api/src/repositories/mongoose/aggregators/get-all-datasheets.ts
@@ -1,0 +1,77 @@
+export function getAllDatasheetsAggregator(filteringAggregators: any, sortAggregator: any) {
+  return [
+    { $sort: { extractionDate: -1 } },
+    latestDatasheetsByNameAggregator,
+    refactorRootAggregator,
+    ...parseCollectionNameAggregator,
+    ...filteringAggregators,
+    refactorOutputAggregator,
+    ...sortAggregator
+  ];
+}
+
+const latestDatasheetsByNameAggregator = {
+  $group: {
+    _id: {
+      name: '$name',
+      owner: '$owner',
+      _collectionId: '$_collectionId',
+    },
+    latestDatasheet: {
+      $first: '$$ROOT',
+    },
+    latestExtractionDate: {
+      $max: '$extractionDate',
+    },
+  },
+};
+
+const refactorRootAggregator = {
+  $replaceRoot: {
+    newRoot: '$latestDatasheet',
+  },
+};
+
+const parseCollectionNameAggregator = [
+  {
+    $lookup: {
+      from: 'datasheetCollections',
+      localField: '_collectionId',
+      foreignField: '_id',
+      as: 'collection',
+    },
+  },
+  {
+    $unwind: {
+      path: '$collection',
+      preserveNullAndEmptyArrays: true,
+    },
+  },
+  {
+    $set: {
+      collectionName: '$collection.name',
+    },
+  },
+];
+
+const refactorOutputAggregator = {
+  $facet: {
+    datasheets: [
+      {
+        $project: {
+          _id: 0,
+          name: 1,
+          owner: 1,
+          collectionName: 1,
+          version: 1,
+          extractionDate: 1,
+          currency: 1,
+          analytics: 1
+        },
+      },
+      {
+        $sort: { name: 1 },
+      },
+    ]
+  }
+};

--- a/api/src/repositories/mongoose/aggregators/get-datasheet-by-name-and-owner.ts
+++ b/api/src/repositories/mongoose/aggregators/get-datasheet-by-name-and-owner.ts
@@ -1,0 +1,72 @@
+export function getDatasheetByNameAndOwnerAggregator(
+  datasheetName: string,
+  owner: string
+) {
+  return [
+    {
+      $match: {
+        name: { $regex: `^${datasheetName}$`, $options: 'i' },
+        owner: { $regex: `^${owner}$`, $options: 'i' },
+      },
+    },
+    {
+      $lookup: {
+        from: 'datasheetCollections',
+        localField: '_collectionId',
+        foreignField: '_id',
+        as: 'collection',
+        pipeline: [{ $project: { name: 1 } }],
+      },
+    },
+    {
+      $lookup: {
+        from: 'users',
+        localField: 'owner',
+        foreignField: 'username',
+        as: 'owner',
+        pipeline: [
+          {
+            $project: {
+              _id: 1,
+              username: 1,
+            },
+          },
+        ],
+      },
+    },
+    { $unwind: { path: '$collection', preserveNullAndEmptyArrays: true } },
+    { $unwind: { path: '$owner', preserveNullAndEmptyArrays: true } },
+    {
+      $group: {
+        _id: { name: '$name', owner: '$owner.username', collectionName: "$collection.name" },
+        name: { $first: '$name' },
+        collectionName: { $first: '$collection.name' },
+        versions: {
+          $push: {
+            id: { $toString: '$_id' },
+            version: '$version',
+            private: '$private',
+            collectionName: { $ifNull: ['$collection.name', null] },
+            extractionDate: '$extractionDate',
+            url: '$url',
+            yaml: '$yaml',
+            analytics: '$analytics',
+            owner: {
+              id: { $toString: '$owner._id' },
+              username: '$owner.username',
+            },
+          },
+        },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        name: 1, // `name` global
+        owner: 1, // `owner` global
+        collectionName: 1,
+        versions: { $sortArray: { input: '$versions', sortBy: { extractionDate: -1 } } }, // Orden descendente por fecha
+      },
+    },
+  ];
+}

--- a/api/src/repositories/mongoose/aggregators/get-datasheets-from-collection.ts
+++ b/api/src/repositories/mongoose/aggregators/get-datasheets-from-collection.ts
@@ -1,0 +1,15 @@
+import { getAllDatasheetsAggregator } from "./get-all-datasheets";
+
+export function getAllDatasheetsFromCollection() {
+  return [lookupForDatasheetsAggregator];
+}
+
+const lookupForDatasheetsAggregator = {
+  $lookup: {
+    from: 'datasheets',
+    localField: '_id',
+    foreignField: '_collectionId',
+    as: 'datasheets',
+    pipeline: getAllDatasheetsAggregator([], []),
+  },
+};

--- a/api/src/repositories/mongoose/models/DatasheetCollectionMongoose.ts
+++ b/api/src/repositories/mongoose/models/DatasheetCollectionMongoose.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema } from 'mongoose';
+
+const datasheetCollectionSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    description: { type: String, required: false },
+    _ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    private: { type: Boolean, required: true, default: false },
+    analytics: { type: Schema.Types.Mixed, required: false },
+  },
+  {
+    toJSON: {
+      virtuals: true,
+      transform: function (doc, resultObject, options) {
+        delete resultObject._id;
+        delete resultObject.__v;
+        delete resultObject._ownerId;
+        return resultObject;
+      },
+    },
+  }
+);
+
+datasheetCollectionSchema.virtual('owner', {
+  ref: 'User',
+  localField: '_ownerId',
+  foreignField: '_id',
+  justOne: true,
+});
+
+// Adding unique index for [name, owner]
+datasheetCollectionSchema.index({ name: 1, _ownerId: 1 }, { unique: true });
+
+const datasheetCollectionModel = mongoose.model(
+  'DatasheetCollection',
+  datasheetCollectionSchema,
+  'datasheetCollections'
+);
+
+export default datasheetCollectionModel;

--- a/api/src/repositories/mongoose/models/DatasheetMongoose.ts
+++ b/api/src/repositories/mongoose/models/DatasheetMongoose.ts
@@ -1,0 +1,39 @@
+import mongoose, { Schema } from 'mongoose';
+
+const datasheetSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    owner: { type: String, required: true },
+    _collectionId: { type: Schema.Types.ObjectId, ref: 'DatasheetCollection', required: false },
+    version: { type: String, required: true },
+    extractionDate: { type: Date, required: true },
+    url: { type: String, required: false },
+    yaml: { type: String, required: true },
+    private: { type: Boolean, required: true, default: false },
+    analytics: { type: Schema.Types.Mixed, required: false },
+  },
+  {
+    toJSON: {
+      virtuals: true,
+      transform: function (doc, resultObject, options) {
+        delete resultObject._id;
+        delete resultObject.__v;
+        return resultObject;
+      },
+    },
+  }
+);
+
+datasheetSchema.virtual('collection', {
+  ref: 'DatasheetCollection',
+  localField: '_collectionId',
+  foreignField: '_id',
+  justOne: true,
+});
+
+// Adding unique index for [name, owner, version]
+datasheetSchema.index({ name: 1, owner: 1, version: 1, _collectionId: 1 }, { unique: true });
+
+const datasheetModel = mongoose.model('Datasheet', datasheetSchema, 'datasheets');
+
+export default datasheetModel;

--- a/api/src/routes/DatasheetCollectionRoutes.ts
+++ b/api/src/routes/DatasheetCollectionRoutes.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import DatasheetCollectionController from '../controllers/DatasheetCollectionController';
+import { isLoggedIn } from '../middlewares/AuthMiddleware';
+import DatasheetController from '../controllers/DatasheetController';
+import { handleCollectionUpload } from '../middlewares/FileHandlerMiddleware';
+import path from 'path';
+
+const loadFileRoutes = function (app: express.Application) {
+  const datasheetCollectionController = new DatasheetCollectionController();
+  const datasheetController = new DatasheetController();
+
+  const upload = handleCollectionUpload(
+    ['zip'],
+    path.resolve(process.cwd(), 'public', 'static', 'datasheetCollections')
+  );
+
+  const baseUrl = process.env.BASE_URL_PATH;
+
+  app
+    .route(baseUrl + '/datasheets/collections')
+    .get(datasheetCollectionController.index)
+    .post(isLoggedIn, datasheetCollectionController.create);
+
+  app
+    .route(baseUrl + '/datasheets/collections/bulk')
+    .post(isLoggedIn, upload, datasheetCollectionController.bulkCreate);
+
+  app.route(baseUrl + '/me/datasheetCollections').get(isLoggedIn, datasheetCollectionController.showByUserId);
+
+  app
+    .route(baseUrl + '/me/datasheetCollections/datasheets/:datasheetName')
+    .delete(isLoggedIn, datasheetController.removeDatasheetFromCollection);
+
+  app
+    .route(baseUrl + '/datasheets/collections/:userId/:collectionName')
+    .get(datasheetCollectionController.showByNameAndUserId)
+    .put(
+      isLoggedIn,
+      datasheetCollectionController.update
+    )
+    .delete(isLoggedIn, datasheetCollectionController.destroy);
+};
+
+export default loadFileRoutes;

--- a/api/src/routes/DatasheetRoutes.ts
+++ b/api/src/routes/DatasheetRoutes.ts
@@ -1,0 +1,37 @@
+import express from 'express';
+import { isLoggedIn } from '../middlewares/AuthMiddleware';
+import DatasheetController from '../controllers/DatasheetController';
+import { handlePricingUpload } from '../middlewares/FileHandlerMiddleware';
+import path from 'path';
+
+const loadFileRoutes = function (app: express.Application) {
+  const datasheetController = new DatasheetController();
+  const upload = handlePricingUpload(
+    ["yaml"],
+    path.resolve(process.cwd(), "public", "static", "datasheets", "uploaded")
+  );
+
+  const baseUrl = process.env.BASE_URL_PATH;
+
+  app
+    .route(baseUrl + '/datasheets')
+    .get(datasheetController.index)
+    .post(isLoggedIn, upload, datasheetController.create);
+
+  app
+    .route(baseUrl + '/datasheets/:owner/:datasheetName')
+    .get(datasheetController.show)
+    .put(isLoggedIn, datasheetController.update)
+    .delete(isLoggedIn, datasheetController.destroyByNameAndOwner);
+  
+  app
+    .route(baseUrl + '/datasheets/:owner/:datasheetName/:datasheetVersion')
+    .delete(isLoggedIn, datasheetController.destroyVersionByNameAndOwner);
+
+  app
+    .route(baseUrl + '/me/datasheets')
+    .get(isLoggedIn, datasheetController.indexByUserWithoutCollection)
+    .put(isLoggedIn, datasheetController.addDatasheetToCollection);
+};
+
+export default loadFileRoutes;

--- a/api/src/services/DatasheetCollectionService.ts
+++ b/api/src/services/DatasheetCollectionService.ts
@@ -1,0 +1,231 @@
+import mongoose from 'mongoose';
+import container from '../config/container';
+import DatasheetCollectionRepository from '../repositories/mongoose/DatasheetCollectionRepository';
+import DatasheetRepository from '../repositories/mongoose/DatasheetRepository';
+import { RetrievedDatasheetCollection } from '../types/database/DatasheetCollection';
+import { DatasheetCollectionIndexQueryParams } from '../types/services/DatasheetCollection';
+import { decompressZip } from '../utils/zip-manager';
+import fs from 'fs';
+
+class DatasheetCollectionService {
+  private readonly datasheetCollectionRepository: DatasheetCollectionRepository;
+  private readonly datasheetRepository: DatasheetRepository;
+
+  constructor() {
+    this.datasheetCollectionRepository = container.resolve('datasheetCollectionRepository');
+    this.datasheetRepository = container.resolve('datasheetRepository');
+  }
+
+  async index(queryParams: DatasheetCollectionIndexQueryParams) {
+    const result = await this.datasheetCollectionRepository.findAll(queryParams);
+    return result;
+  }
+
+  async showByNameAndUserId(name: string, userId: string) {
+    const collection = await this.datasheetCollectionRepository.findByNameAndUserId(name, userId);
+    if (!collection) {
+      throw new Error('Datasheet collection not found');
+    }
+
+    return collection;
+  }
+
+  async showByUserId(userId: string) {
+    const collections = await this.datasheetCollectionRepository.findByUserId(userId);
+    return collections;
+  }
+
+  async show(userId: string) {
+    const collection = await this.datasheetCollectionRepository.findByUserId(userId);
+    if (!collection) {
+      throw new Error('Datasheet collection not found');
+    }
+
+    return collection;
+  }
+
+  async create(newCollection: any, userId: string, username: string) {
+    let collection: any;
+    try {
+      newCollection._ownerId = new mongoose.Types.ObjectId(userId);
+      newCollection.analytics = {};
+
+      collection = await this.datasheetCollectionRepository.create(newCollection);
+
+      if (newCollection.datasheets && newCollection.datasheets.length > 0) {
+        await this.datasheetRepository.addDatasheetsToCollection(
+          collection._id.toString(),
+          username,
+          newCollection.datasheets
+        );
+      }
+
+      await this.updateCollectionAnalytics(collection._id.toString());
+
+      return collection;
+    } catch (err) {
+      await this._handleCollectionCreationError(err as Error, collection, newCollection, userId);
+    }
+  }
+
+  async bulkCreate(file: any, newCollectionData: any, userId: string, username: string) {
+    let collection: any;
+    try {
+      const extractPath = this._getExtractPath(userId, newCollectionData.name);
+      const zipPath = file.path;
+
+      const extractedFiles = await decompressZip(zipPath, extractPath);
+
+      newCollectionData._ownerId = new mongoose.Types.ObjectId(userId);
+
+      collection = await this.datasheetCollectionRepository.create(newCollectionData);
+
+      const datasheetDatas = [];
+      const datasheetsWithErrors = [];
+      for (const datasheet of extractedFiles) {
+        if (!(datasheet.endsWith('.yaml') || datasheet.endsWith('.yml'))) {
+          continue
+        }
+        try{
+          const fileContent = fs.readFileSync(datasheet, 'utf8');
+
+          let extractedName = datasheet.split('/').pop()?.split('.')[0] || 'UnknownDatasheet';
+          let extractedVersion = '1.0.0';
+          let extractedCreatedAt = new Date();
+    
+          const nameMatch = fileContent.match(/saasName:\s*([^\s\n]+)/);
+          if (nameMatch) extractedName = nameMatch[1];
+          
+          const versionMatch = fileContent.match(/version:\s*([^\s\n]+)/);
+          if (versionMatch) extractedVersion = versionMatch[1];
+
+          const datasheetData = {
+            name: extractedName,
+            version: extractedVersion,
+            _collectionId: collection._id,
+            owner: username,
+            extractionDate: extractedCreatedAt,
+            url: '',
+            yaml: datasheet.split('/').slice(1).join('/'),
+            analytics: {},
+          };
+          datasheetDatas.push(datasheetData);
+        }catch(err){
+          datasheetsWithErrors.push({
+            name: `${datasheet.split("/")[datasheet.split("/").length - 2]}/${datasheet.split("/")[datasheet.split("/").length - 1]}`,
+            error: err,
+          });
+        }
+      }
+
+      if (datasheetDatas.length > 0) {
+        await this.datasheetRepository.create(datasheetDatas);
+      }
+
+      await this.updateCollectionAnalytics(collection._id.toString());
+
+      return [collection, datasheetsWithErrors];
+    } catch(err) {
+      throw await this._handleCollectionCreationError(err as Error, collection, newCollectionData, userId);
+    }
+  }
+
+  async update(collectionName: string, ownerId: string, data: any) {
+    const collection = await this.datasheetCollectionRepository.findByNameAndUserId(
+      collectionName,
+      ownerId
+    );
+    if (!collection) {
+      throw new Error('Either the collection does not exist or you are not its owner');
+    }
+
+    await this.datasheetCollectionRepository.update(collection._id.toString(), data);
+
+    const updatedCollection = await this.datasheetCollectionRepository.findById(collection._id.toString());
+
+    if (updatedCollection.name !== collectionName) {
+      if (fs.existsSync(this._getExtractPath(ownerId, collectionName))) {
+        fs.renameSync(
+            this._getExtractPath(ownerId, collectionName),
+            this._getExtractPath(ownerId, updatedCollection.name)
+        );
+      }
+    }
+
+    return updatedCollection;
+  }
+
+  async updateCollectionAnalytics(collectionId: string) {
+    const collection = await this.datasheetCollectionRepository.findById(collectionId);
+
+    if (!collection) {
+      throw new Error('Datasheet collection not found');
+    }
+
+    const newAnalyticsEntry = this._computeCollectionAnalytics(collection);
+
+    if (newAnalyticsEntry) {
+        // Here we could implement collection analytics updates if requested later
+        // await this.datasheetCollectionRepository.updateAnalytics(collection._id, newAnalyticsEntry);
+    }
+  }
+
+  async destroy(collectionName: string, ownerId: string, deleteCascade: boolean, ignoreResult: boolean = false) {
+    const collection = await this.datasheetCollectionRepository.findByNameAndUserId(
+      collectionName,
+      ownerId
+    );
+    if (!collection) {
+      throw new Error('Either the collection does not exist or you are not its owner');
+    }
+
+    let result;
+
+    if (deleteCascade) {
+      result = await this.datasheetCollectionRepository.destroyWithDatasheets(
+        collection._id.toString()
+      );
+      
+      const extractPath = this._getExtractPath(ownerId, collectionName);
+      if (fs.existsSync(extractPath)) fs.rmdirSync(extractPath, { recursive: true });
+    } else {
+      await this.datasheetRepository.removeDatasheetsFromCollection(collection._id.toString());
+      result = await this.datasheetCollectionRepository.destroy(collection._id.toString());
+    }
+
+    if (!result && !ignoreResult) {
+      throw new Error('Collection not found');
+    }
+
+    return true;
+  }
+
+  _computeCollectionAnalytics(collection: RetrievedDatasheetCollection) {
+      return {};
+  }
+
+
+  _getExtractPath(userId: string, collectionName: string) {
+    return `${process.env.COLLECTIONS_FOLDER}/${userId}/${collectionName}`;
+  }
+
+  async _handleCollectionCreationError(err: Error, collection: any, newCollectionData: any, userId: string): Promise<Error> {
+      try {
+        if (collection?._id) {
+          await this.destroy(newCollectionData.name, userId, true, true);
+        }
+      } catch (cleanupErr) {
+        console.error('Error during cleanup after bulkCreate failure:', cleanupErr);
+      }
+
+      const errMsg = (err as any)?.message || String(err);
+
+      if (errMsg.includes('E11000') || errMsg.toLowerCase().includes('duplicate') || errMsg.toLowerCase().includes('already exists')) {
+        throw new Error('A collection with this name already exists. Please choose another name.');
+      }
+
+      throw new Error(errMsg);
+  }
+}
+
+export default DatasheetCollectionService;

--- a/api/src/services/DatasheetService.ts
+++ b/api/src/services/DatasheetService.ts
@@ -1,0 +1,234 @@
+import { Datasheet as DatasheetModel } from '../types/database/Datasheet';
+import container from '../config/container';
+import { processFileUris } from './FileService';
+import { DatasheetIndexQueryParams } from '../types/services/DatasheetService';
+import DatasheetCollectionService from './DatasheetCollectionService';
+import DatasheetRepository from '../repositories/mongoose/DatasheetRepository';
+import DatasheetMongoose from '../repositories/mongoose/models/DatasheetMongoose';
+import CacheService from './CacheService';
+import fs from 'fs';
+
+class DatasheetService {
+  private datasheetRepository: DatasheetRepository;
+  private datasheetCollectionService: DatasheetCollectionService;
+  private cacheService: CacheService;
+
+  constructor() {
+    this.datasheetRepository = container.resolve('datasheetRepository');
+    this.datasheetCollectionService = container.resolve('datasheetCollectionService');
+    this.cacheService = container.resolve('cacheService');
+  }
+
+  async index(queryParams: DatasheetIndexQueryParams) {
+    const datasheets = await this.datasheetRepository.findAll(queryParams);
+    return datasheets;
+  }
+
+  async indexByUserWithoutCollection(username: string) {
+    const datasheets = await this.datasheetRepository.findByOwnerWithoutCollection(username);
+    return datasheets;
+  }
+
+  async indexByCollection(collectionId: string) {
+    const datasheets = await this.datasheetRepository.findByCollection(collectionId);
+    return datasheets;
+  }
+
+  async show(name: string, owner: string, queryParams?: { collectionName?: string }) {
+    const datasheet: { name: string; versions: DatasheetModel[] } | null =
+      await this.datasheetRepository.findByNameAndOwner(name, owner, queryParams);
+    if (!datasheet) {
+      throw new Error('Datasheet not found');
+    }
+    for (const version of datasheet.versions) {
+      processFileUris(version, ['yaml']);
+    }
+    const datasheetObject = Object.assign({}, datasheet);
+    return datasheetObject;
+  }
+
+  async create(datasheetFile: any, owner: string, collectionId?: string) {
+    try {
+      const filePath = typeof datasheetFile === 'string' ? datasheetFile : datasheetFile.path;
+      const fileContent = fs.readFileSync(filePath, 'utf8');
+
+      // Simple extraction of saasName and version for datasheets
+      // If none found, we default to the filename and version 1.0.0
+      let extractedName = filePath.split('/').pop()?.split('.')[0] || 'UnknownDatasheet';
+      let extractedVersion = '1.0.0';
+      let extractedCreatedAt = new Date();
+
+      const nameMatch = fileContent.match(/saasName:\s*([^\s\n]+)/);
+      if (nameMatch) extractedName = nameMatch[1];
+      
+      const versionMatch = fileContent.match(/version:\s*([^\s\n]+)/);
+      if (versionMatch) extractedVersion = versionMatch[1];
+
+      const previousDatasheet = await this.datasheetRepository.findByNameAndOwner(
+        extractedName,
+        owner
+      );
+
+      if (!collectionId && previousDatasheet && previousDatasheet.versions[0]._collectionId) {
+        collectionId = previousDatasheet.versions[0]._collectionId.toString();
+      }
+
+      const datasheetData = {
+        name: extractedName,
+        version: extractedVersion,
+        _collectionId: collectionId,
+        owner: owner,
+        extractionDate: extractedCreatedAt,
+        url: '',
+        yaml: filePath.split(/[/\\]/).slice(filePath.split(/[/\\]/).indexOf("public") >= 0 ? filePath.split(/[/\\]/).indexOf("public") : 1).join("/"),
+        analytics: {},
+      };
+
+      const datasheet = await this.datasheetRepository.create([datasheetData]);
+
+      processFileUris(datasheet[0], ['yaml']);
+
+      // Collections do not have heavy analytics right now
+      if (collectionId) {
+        await this.datasheetCollectionService.updateCollectionAnalytics(collectionId);
+      }
+
+      return datasheet;
+    } catch (err) {
+      throw new Error((err as Error).message);
+    }
+  }
+
+  async addDatasheetToCollection(datasheetName: string, owner: string, collectionId: string) {
+    try {
+      const datasheet = await this.datasheetRepository.findByNameAndOwner(datasheetName, owner);
+      if (!datasheet) {
+        throw new Error('Either the datasheet does not exist or you are not its owner');
+      }
+
+      await this.datasheetRepository.addDatasheetToCollection(datasheetName, owner, collectionId);
+      await this.datasheetCollectionService.updateCollectionAnalytics(collectionId);
+
+      return true;
+    } catch (err) {
+      throw new Error((err as Error).message);
+    }
+  }
+
+  async update(datasheetName: string, owner: string, data: any) {
+    const datasheet = await this.datasheetRepository.findByNameAndOwner(datasheetName, owner);
+    if (!datasheet) {
+      throw new Error('Either the datasheet does not exist or you are not its owner');
+    }
+
+    for (const datasheetVersion of datasheet.versions) {
+      await this.datasheetRepository.update(datasheetVersion.id, data);
+    }
+
+    const updatedDatasheet = await this.datasheetRepository.findByNameAndOwner(datasheetName, owner);
+
+    return updatedDatasheet;
+  }
+
+  async updateDatasheetsCollectionName(
+    oldCollectionName: string,
+    newCollectionName: string,
+    collectionId: string,
+    ownerId: string
+  ) {
+    if (oldCollectionName === newCollectionName) {
+      return true;
+    }
+
+    const datasheets = await this.datasheetRepository.findByCollection(collectionId);
+    const datasheetsToUpdate = [];
+    for (const datasheet of datasheets) {
+      if (datasheet.yaml.includes(oldCollectionName)) {
+        datasheet.yaml = datasheet.yaml.replace(oldCollectionName, newCollectionName);
+        datasheetsToUpdate.push(datasheet);
+      }
+    }
+
+    await this.datasheetRepository.updateDatasheetsCollectionName(
+      datasheetsToUpdate,
+      ownerId,
+      newCollectionName
+    );
+    return true;
+  }
+
+  async removeDatasheetFromCollection(datasheetName: string, owner: string) {
+    try {
+      const datasheet = await DatasheetMongoose.findOne({ name: datasheetName, owner });
+
+      if (!datasheet) {
+        throw new Error('Either the datasheet does not exist or you are not its owner');
+      }
+
+      await this.datasheetRepository.removeDatasheetFromCollection(datasheetName, owner);
+      if (datasheet._collectionId) {
+        await this.datasheetCollectionService.updateCollectionAnalytics(
+          datasheet._collectionId.toString()
+        );
+      } else {
+        throw new Error('Datasheet is not in a collection');
+      }
+
+      return true;
+    } catch (err) {
+      throw new Error((err as Error).message);
+    }
+  }
+
+  async destroy(datasheetName: string, owner: string, queryParams?: { collectionName?: string }) {
+    let collectionId;
+
+    if (queryParams?.collectionName) {
+      const collection = await this.datasheetCollectionService.showByNameAndUserId(
+        queryParams.collectionName,
+        owner
+      );
+      if (!collection) {
+        throw new Error('Collection not found');
+      }
+
+      collectionId = collection._id.toString();
+    }
+
+    const result = await this.datasheetRepository.destroyByNameOwnerAndCollectionId(
+      datasheetName,
+      owner,
+      collectionId
+    );
+    if (!result) {
+      throw new Error('Either the datasheet does not exist or you are not its owner');
+    }
+    return true;
+  }
+
+  async destroyVersion(datasheetName: string, datasheetVersion: string, owner: string) {
+    let result;
+
+    result = await this.datasheetRepository.destroyVersionByNameAndOwner(
+      datasheetName,
+      datasheetVersion,
+      owner
+    );
+
+    if (!result) {
+      result = await this.datasheetRepository.destroyVersionByNameAndOwner(
+        datasheetName,
+        datasheetVersion.replace('_', '.'),
+        owner
+      );
+    }
+
+    if (!result) {
+      throw new Error('Either the datasheet does not exist or you are not its owner');
+    }
+
+    return true;
+  }
+}
+
+export default DatasheetService;

--- a/api/src/types/database/Datasheet.ts
+++ b/api/src/types/database/Datasheet.ts
@@ -1,0 +1,10 @@
+export interface Datasheet {
+  id: string;
+  name: string;
+  _collectionId?: string;
+  extractionDate: Date;
+  url?: string;
+  yaml: string;
+  // Currently no specific analytics for datasheets, but we keep it open for future
+  analytics?: any;
+}

--- a/api/src/types/database/DatasheetCollection.ts
+++ b/api/src/types/database/DatasheetCollection.ts
@@ -1,0 +1,14 @@
+import { User } from "./User";
+
+export interface DatasheetCollection {
+    name: string,
+    owner: User,
+    analytics?: any
+}
+
+export interface RetrievedDatasheetCollection {
+    name: string,
+    owner: User,
+    datasheets: any,
+    analytics?: any
+}

--- a/api/src/types/services/DatasheetCollection.ts
+++ b/api/src/types/services/DatasheetCollection.ts
@@ -1,0 +1,8 @@
+export interface DatasheetCollectionIndexQueryParams {
+    limit?: string | number,
+    offset?: string | number,
+    name?: string,
+    selectedOwners?: string[],
+    sortBy?: string,
+    sort?: "asc" | "desc",
+}

--- a/api/src/types/services/DatasheetService.ts
+++ b/api/src/types/services/DatasheetService.ts
@@ -1,0 +1,8 @@
+export interface DatasheetIndexQueryParams {
+    limit?: string | number,
+    offset?: string | number,
+    name?: string,
+    selectedOwners?: string[],
+    sortBy?: string,
+    sort?: "asc" | "desc",
+}


### PR DESCRIPTION
# 🛠️ Pull Request

## 📖 Contexto
Se ha introducido la primera versión de la API de datasheet.

---

## 🏗️ Cambios realizados
- Se han añadido los CRUD para poder manejar los datasheet y las colecciones dentro de SPHERE.

---

## 🚦 Checklist de Calidad
- [ X] 🧪 **Pruebas:** He verificado que los cambios funcionan correctamente.
- [ X] 🧹 **Limpieza:** El código no incluye logs innecesarios ni código comentado.
- [ ] 📋 **Documentación:** He actualizado el README o la documentación si era necesario.
- [ ] 💻 **Compatibilidad:** Se ha verificado que funciona en diferentes entornos (si aplica).

---

## 🧪 ¿Cómo probar estos cambios?
1. Adjunte un postman por el grupo de whassap con las pruebas de postman.
2. Si no se dispone des postman, probar que la API interactua con el servidor.

